### PR TITLE
Update @modelcontextprotocol/sdk version to 1.0.3 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Josh Rutkowski",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^0.1.0"
+    "@modelcontextprotocol/sdk": "^1.0.3"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
Updating the sdk version fixes the errors for claude to load the MCP.