### PR TITLE
Add Mail.app Integration for Email Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ This server provides a standardized interface for AI applications to control sys
 - 🔔 System notifications
 - ⚙️ System controls (volume, dark mode, apps)
 - 📟 iTerm terminal integration
+- 📬 Mail (create new email)
 
 ### Planned Features
+
 - 📬 Mail (list emails, save attachments, summarize, send)
 - 🧭 Safari (open in Safari, save page content, get selected page/tab)
 - 💬 Messages (send, get, list)
@@ -27,49 +29,56 @@ This server provides a standardized interface for AI applications to control sys
 ## Available Categories
 
 ### Calendar
-| Command | Description | Parameters |
-|---------|-------------|------------|
-| `add` | Create calendar event | `title`, `startDate`, `endDate` |
-| `list` | List today's events | None |
+
+| Command | Description           | Parameters                      |
+| ------- | --------------------- | ------------------------------- |
+| `add`   | Create calendar event | `title`, `startDate`, `endDate` |
+| `list`  | List today's events   | None                            |
 
 ### Clipboard
-| Command | Description | Parameters |
-|---------|-------------|------------|
-| `set_clipboard` | Copy to clipboard | `content` |
-| `get_clipboard` | Get clipboard contents | None |
-| `clear_clipboard` | Clear clipboard | None |
+
+| Command           | Description            | Parameters |
+| ----------------- | ---------------------- | ---------- |
+| `set_clipboard`   | Copy to clipboard      | `content`  |
+| `get_clipboard`   | Get clipboard contents | None       |
+| `clear_clipboard` | Clear clipboard        | None       |
 
 ### Finder
-| Command | Description | Parameters |
-|---------|-------------|------------|
-| `get_selected_files` | Get selected files | None |
-| `search_files` | Search for files | `query`, `location` (optional) |
-| `quick_look` | Preview file | `path` |
+
+| Command              | Description        | Parameters                     |
+| -------------------- | ------------------ | ------------------------------ |
+| `get_selected_files` | Get selected files | None                           |
+| `search_files`       | Search for files   | `query`, `location` (optional) |
+| `quick_look`         | Preview file       | `path`                         |
 
 ### Notifications
-| Command | Description | Parameters |
-|---------|-------------|------------|
-| `send_notification` | Show notification | `title`, `message`, `sound` (optional) |
-| `toggle_do_not_disturb` | Toggle DND mode | None |
+
+| Command                 | Description       | Parameters                             |
+| ----------------------- | ----------------- | -------------------------------------- |
+| `send_notification`     | Show notification | `title`, `message`, `sound` (optional) |
+| `toggle_do_not_disturb` | Toggle DND mode   | None                                   |
 
 ### System
-| Command | Description | Parameters |
-|---------|-------------|------------|
-| `volume` | Set system volume | `level` (0-100) |
-| `get_frontmost_app` | Get active app | None |
-| `launch_app` | Open application | `name` |
-| `quit_app` | Close application | `name`, `force` (optional) |
-| `toggle_dark_mode` | Toggle dark mode | None |
+
+| Command             | Description       | Parameters                 |
+| ------------------- | ----------------- | -------------------------- |
+| `volume`            | Set system volume | `level` (0-100)            |
+| `get_frontmost_app` | Get active app    | None                       |
+| `launch_app`        | Open application  | `name`                     |
+| `quit_app`          | Close application | `name`, `force` (optional) |
+| `toggle_dark_mode`  | Toggle dark mode  | None                       |
 
 ### iTerm
-| Command | Description | Parameters |
-|---------|-------------|------------|
-| `paste_clipboard` | Paste to iTerm | None |
-| `run` | Execute command | `command`, `newWindow` (optional) |
+
+| Command           | Description     | Parameters                        |
+| ----------------- | --------------- | --------------------------------- |
+| `paste_clipboard` | Paste to iTerm  | None                              |
+| `run`             | Execute command | `command`, `newWindow` (optional) |
 
 ## Development
 
 ### Setup
+
 ```bash
 # Install dependencies
 npm install
@@ -85,7 +94,9 @@ npx @modelcontextprotocol/inspector node path/to/server/index.js args...
 ### Adding New Functionality
 
 #### 1. Create Category File
+
 Create `src/categories/newcategory.ts`:
+
 ```typescript
 import { ScriptCategory } from "../types/index.js";
 
@@ -94,11 +105,12 @@ export const newCategory: ScriptCategory = {
   description: "Category description",
   scripts: [
     // Scripts will go here
-  ]
+  ],
 };
 ```
 
 #### 2. Add Scripts
+
 ```typescript
 {
   name: "script_name",
@@ -122,7 +134,9 @@ export const newCategory: ScriptCategory = {
 ```
 
 #### 3. Register Category
+
 Update `src/index.ts`:
+
 ```typescript
 import { newCategory } from "./categories/newcategory.js";
 // ...
@@ -132,6 +146,7 @@ server.addCategory(newCategory);
 ## Debugging
 
 ### Using MCP Inspector
+
 The MCP Inspector provides a web interface for testing and debugging your server:
 
 ```bash
@@ -139,12 +154,15 @@ npm run inspector
 ```
 
 ### Logging
+
 Enable debug logging by setting the environment variable:
+
 ```bash
 DEBUG=applescript-mcp* npm start
 ```
 
 ### Common Issues
+
 - **Permission Errors**: Check System Preferences > Security & Privacy
 - **Script Failures**: Test scripts directly in Script Editor.app
 - **Communication Issues**: Check stdio streams aren't being redirected

--- a/src/categories/mail.ts
+++ b/src/categories/mail.ts
@@ -1,0 +1,72 @@
+import { ScriptCategory } from "../types/index.js";
+
+/**
+ * Mail-related scripts.
+ * * create_email: Create a new email in Mail.app with specified recipient, subject, and body
+ */
+export const mailCategory: ScriptCategory = {
+  name: "mail",
+  description: "Mail operations",
+  scripts: [
+    {
+      name: "create_email",
+      description: "Create a new email in Mail.app",
+      schema: {
+        type: "object",
+        properties: {
+          recipient: {
+            type: "string",
+            description: "Email recipient",
+          },
+          subject: {
+            type: "string",
+            description: "Email subject",
+          },
+          body: {
+            type: "string",
+            description: "Email body",
+          },
+        },
+        required: ["recipient", "subject", "body"],
+      },
+      script: (args) => `
+        set recipient to "${args.recipient}"
+        set subject to "${args.subject}"
+        set body to "${args.body}"
+
+        -- URL encode subject and body
+        set encodedSubject to my urlEncode(subject)
+        set encodedBody to my urlEncode(body)
+
+        -- Construct the mailto URL
+        set mailtoURL to "mailto:" & recipient & "?subject=" & encodedSubject & "&body=" & encodedBody
+
+        -- Use Apple Mail's 'mailto' command to create the email
+        tell application "Mail"
+          mailto mailtoURL
+          activate
+        end tell
+
+        -- Handler to URL-encode text
+        on urlEncode(theText)
+          set theEncodedText to ""
+          set theChars to every character of theText
+          repeat with aChar in theChars
+            set charCode to ASCII number aChar
+            if charCode = 32 then
+              set theEncodedText to theEncodedText & "%20" -- Space
+            else if (charCode ≥ 48 and charCode ≤ 57) or (charCode ≥ 65 and charCode ≤ 90) or (charCode ≥ 97 and charCode ≤ 122) or charCode = 45 or charCode = 46 or charCode = 95 or charCode = 126 then
+              -- Allowed characters: A-Z, a-z, 0-9, -, ., _, ~
+              set theEncodedText to theEncodedText & aChar
+            else
+              -- Convert to %HH format
+              set hexCode to do shell script "printf '%02X' " & charCode
+              set theEncodedText to theEncodedText & "%" & hexCode
+            end if
+          end repeat
+          return theEncodedText
+        end urlEncode
+      `,
+    },
+  ],
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { finderCategory } from "./categories/finder.js";
 import { clipboardCategory } from "./categories/clipboard.js";
 import { notificationsCategory } from "./categories/notifications.js";
 import { itermCategory } from "./categories/iterm.js";
+import { mailCategory } from "./categories/mail.js";
 
 const server = new AppleScriptFramework({
   name: "applescript-server",
@@ -19,6 +20,7 @@ server.addCategory(finderCategory);
 server.addCategory(clipboardCategory);
 server.addCategory(notificationsCategory);
 server.addCategory(itermCategory);
+server.addCategory(mailCategory);
 
 // Start the server
 server.run().catch(console.error);


### PR DESCRIPTION
This PR introduces Mail.app integration to the AppleScript MCP server, adding the ability to programmatically create new emails. Key changes:

- Adds new mailCategory with initial create_email functionality
- Implements proper URL encoding for subject and body text to handle special characters
- Uses Mail.app's mailto protocol for reliable email creation
- Includes input validation through JSON schema for recipient, subject, and body fields

The implementation uses AppleScript's native URL handling capabilities combined with proper character encoding to ensure reliable email creation across different text inputs. 

Note: the `mailto` command in AppleScript provides a workaround for a strange quirky inclusion of a carriage return in Apple Mail using the `make new message` method that turns the message into quoted message rather than the main body.