### PR TITLE
Add Pages.app Document Operations Category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 *.log
 .env*
 /dist
+helps/*
+.DS_Store

--- a/src/categories/pages.ts
+++ b/src/categories/pages.ts
@@ -28,6 +28,7 @@ export const pagesCategory: ScriptCategory = {
             set newDoc to make new document
             
             set the body text of newDoc to "${args.content.replace(/"/g, '\\"')}"
+            activate
             return "Document created successfully with plain text content"
           end tell
         on error errMsg

--- a/src/categories/pages.ts
+++ b/src/categories/pages.ts
@@ -1,0 +1,39 @@
+import { ScriptCategory } from "../types/index.js";
+
+/**
+ * Pages-related scripts.
+ * * create_document: Create a new Pages document with plain text content
+ */
+export const pagesCategory: ScriptCategory = {
+  name: "pages",
+  description: "Pages document operations",
+  scripts: [
+    {
+      name: "create_document",
+      description: "Create a new Pages document with plain text content (no formatting)",
+      schema: {
+        type: "object",
+        properties: {
+          content: {
+            type: "string",
+            description: "The plain text content to add to the document (no formatting)"
+          }
+        },
+        required: ["content"]
+      },
+      script: (args) => `
+        try
+          tell application "Pages"
+            -- Create new document
+            set newDoc to make new document
+            
+            set the body text of newDoc to "${args.content.replace(/"/g, '\\"')}"
+            return "Document created successfully with plain text content"
+          end tell
+        on error errMsg
+          return "Failed to create document: " & errMsg
+        end try
+      `
+    }
+  ]
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { finderCategory } from "./categories/finder.js";
 import { clipboardCategory } from "./categories/clipboard.js";
 import { notificationsCategory } from "./categories/notifications.js";
 import { itermCategory } from "./categories/iterm.js";
+import { pagesCategory } from "./categories/pages.js";
 
 const server = new AppleScriptFramework({
   name: "applescript-server",
@@ -19,6 +20,7 @@ server.addCategory(finderCategory);
 server.addCategory(clipboardCategory);
 server.addCategory(notificationsCategory);
 server.addCategory(itermCategory);
+server.addCategory(pagesCategory);
 
 // Start the server
 server.run().catch(console.error);


### PR DESCRIPTION
### Changes

- Added new pagesCategory for Apple Pages document operations
- Implemented create_document script to create new Pages documents with plain text content

### Technical Details

- Uses AppleScript to interact with Pages application
- Handles string escaping for quotes in document content
- Includes error handling with descriptive error messages
- Document creation is limited to plain text content (no formatting support)

### Limitations

- Currently only supports plain text content (no rich text formatting)

_Thank you for considering my pull request!_