### PR TITLE
Change 'message' to 'logger' in sendLoggingMessage

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -158,7 +158,7 @@ export class AppleScriptFramework {
       try {
         this.server.sendLoggingMessage({
           level: level,
-          message: message,
+          logger: message,
           data: data || {},
         });
       } catch (error) {


### PR DESCRIPTION
For some reason build for me complains sendLoggingMessage has no param for message, saw optional logger there.

```
src/framework.ts:161:11 - error TS2353: Object literal may only specify known properties, and 'message' does not exist in type '{ level: "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug"; data: unknown; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { ...; } | undefined; } | undefined; logger?: string | undefined; }'.

161           message: message,
              ~~~~~~~
```